### PR TITLE
Create an Arch Linux ARM install guide and change absolute paths

### DIFF
--- a/Mu-Qcom/Devices/Galaxy-Tab-S8-5G/Mass-Storage.md
+++ b/Mu-Qcom/Devices/Galaxy-Tab-S8-5G/Mass-Storage.md
@@ -9,9 +9,9 @@ This Guide will show you how to enable Mass Storage in TWRP for the Galaxy Tab S
 <tr><td>
   
 - Enabling Mass Storage
-   - [What's needed](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Galaxy-Tab-S8-5G/Mass-Storage.md#things-you-need)
-   - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Galaxy-Tab-S8-5G/Mass-Storage.md#preparing-step-1)
-   - [Enable](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Galaxy-Tab-S8-5G/Mass-Storage.md#enable-mass-storage-step-2)
+   - [What's needed](#things-you-need)
+   - [Preparing](#preparing-step-1)
+   - [Enable](#enable-mass-storage-step-2)
 
 </td></tr> </table>
 
@@ -19,7 +19,7 @@ This Guide will show you how to enable Mass Storage in TWRP for the Galaxy Tab S
    - PC / Laptop
    - [TWRP](https://forum.xda-developers.com/t/recovery-unofficial-twrp-for-galaxy-tab-s8-series-snapdragon.4455491/)
    - Unlocked Bootloader
-   - Modded [msc.sh](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Galaxy-Tab-S8-5G/msc.sh) script
+   - Modded [msc.sh](msc.sh) script
 
 ## Preparing (Step 1)
 

--- a/Mu-Qcom/Devices/OnePlus-8T/Mass-Storage.md
+++ b/Mu-Qcom/Devices/OnePlus-8T/Mass-Storage.md
@@ -9,10 +9,10 @@ This Guide will show you how to enable Mass Storage in OrangeFox for OnePlus 8T.
 <tr><td>
   
 - Enabling Mass Storage
-   - [What's needed](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/OnePlus-8T/Mass-Storage.md#things-you-need)
-   - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/OnePlus-8T/Mass-Storage.md#preparing-step-1)
-   - [Enable](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/OnePlus-8T/Mass-Storage.md#enable-mass-storage-step-2)
-   - [Driver](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/OnePlus-8T/Mass-Storage.md#enable-mass-storage-step-2.1)
+   - [What's needed](#things-you-need)
+   - [Preparing](#preparing-step-1)
+   - [Enable](#enable-mass-storage-step-2)
+   - [Driver](#enable-mass-storage-step-2.1)
 
 </td></tr> </table>
 
@@ -20,7 +20,7 @@ This Guide will show you how to enable Mass Storage in OrangeFox for OnePlus 8T.
    - PC / Laptop
    - [OrangeFox](https://github.com/Wishmasterflo/android_device_oneplus_kebab/releases/download/V15/OrangeFox-R11.1-Unofficial-OnePlus8T_9R-V15.img)
    - Unlocked Bootloader
-   - Modded [msc.sh](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/OnePlus-8T/msc.sh) script
+   - Modded [msc.sh](msc.sh) script
 
 ## Preparing (Step 1)
 
@@ -41,7 +41,7 @@ chmod 755 /cache/msc.sh
 ## Driver (Step 2.1)
 
 If your phone appears in Device Manager as MTP with an exclamation point, then install the driver as shown in the screenshot:
-<img align="right" src="https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/OnePlus-8T/Install-Driver.png" width="500" alt="Preview">
+<img align="right" src="Install-Driver.png" width="500" alt="Preview">
 
 There will be some errors in output but that dosen't break anything. <br />
 On your PC or Laptop should now show up all the partitions of your Phone from LUN 0.

--- a/Mu-Qcom/Devices/Xiaomi-Mi-Max-3/Mass-Storage.md
+++ b/Mu-Qcom/Devices/Xiaomi-Mi-Max-3/Mass-Storage.md
@@ -9,9 +9,9 @@ This Guide will show you how to enable Mass Storage in TWRP for Xiaomi Mi Max 3.
 <tr><td>
   
 - Enabling Mass Storage
-   - [What's needed](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Mi-Max-3/Mass-Storage.md#things-you-need)
-   - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Mi-Max-3/Mass-Storage.md#preparing-step-1)
-   - [Enable](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Mi-Max-3/Mass-Storage.md#enable-mass-storage-step-2)
+   - [What's needed](#things-you-need)
+   - [Preparing](#preparing-step-1)
+   - [Enable](#enable-mass-storage-step-2)
 
 </td></tr> </table>
 
@@ -19,7 +19,7 @@ This Guide will show you how to enable Mass Storage in TWRP for Xiaomi Mi Max 3.
    - PC / Laptop
    - TWRP
    - Unlocked Bootloader
-   - Modded [msc.sh](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Mi-Max-3/msc.sh) script
+   - Modded [msc.sh](msc.sh) script
 
 ## Preparing (Step 1)
 

--- a/Mu-Qcom/Devices/Xiaomi-Redmi-10C/Mass-Storage.md
+++ b/Mu-Qcom/Devices/Xiaomi-Redmi-10C/Mass-Storage.md
@@ -9,9 +9,9 @@ This Guide will show you how to enable Mass Storage in TWRP for Xiaomi Redmi 10C
 <tr><td>
   
 - Enabling Mass Storage
-   - [What's needed](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-10C/Mass-Storage.md#things-you-need)
-   - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-10C/Mass-Storage.md#preparing-step-1)
-   - [Enable](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-10C/Mass-Storage.md#enable-mass-storage-step-2)
+   - [What's needed](#things-you-need)
+   - [Preparing](#preparing-step-1)
+   - [Enable](#enable-mass-storage-step-2)
 
 </td></tr> </table>
 
@@ -19,7 +19,7 @@ This Guide will show you how to enable Mass Storage in TWRP for Xiaomi Redmi 10C
    - PC / Laptop
    - TWRP
    - Unlocked Bootloader
-   - Modded [msc.sh](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-10C/msc.sh) script
+   - Modded [msc.sh](msc.sh) script
 
 ## Preparing (Step 1)
 

--- a/Mu-Qcom/Devices/Xiaomi-Redmi-Note-8/Mass-Storage.md
+++ b/Mu-Qcom/Devices/Xiaomi-Redmi-Note-8/Mass-Storage.md
@@ -9,9 +9,9 @@ This Guide will show you how to enable Mass Storage in OrangeFox for Xiaomi Redm
 <tr><td>
   
 - Enabling Mass Storage
-   - [What's needed](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-Note-8/Mass-Storage.md#things-you-need)
-   - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-Note-8/Mass-Storage.md#preparing-step-1)
-   - [Enable](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-Note-8/Mass-Storage.md#enable-mass-storage-step-2)
+   - [What's needed](#things-you-need)
+   - [Preparing](#preparing-step-1)
+   - [Enable](#enable-mass-storage-step-2)
 
 </td></tr> </table>
 
@@ -19,7 +19,7 @@ This Guide will show you how to enable Mass Storage in OrangeFox for Xiaomi Redm
    - PC / Laptop
    - [OrangeFox](https://orangefox.download/device/ginkgo)
    - Unlocked Bootloader
-   - Modded [msc.sh](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-Note-8/msc.sh) script
+   - Modded [msc.sh](msc.sh) script
 
 ## Preparing (Step 1)
 

--- a/Mu-Qcom/General/Boot.md
+++ b/Mu-Qcom/General/Boot.md
@@ -9,12 +9,12 @@ This Guide will show your how to boot UEFI on your Device.
 <tr><td>
 
 - Booting UEFI
-    - [Requirements](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/General/Boot.md#recuirements)
-    - [Getting UEFI](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/General/Boot.md#getting-uefi)
-    - [Method 1](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/General/Boot.md#booting-uefi-method-1-recommended)
-    - [Method 2](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/General/Boot.md#flashing-uefi-method-2)
-       - [Fastboot](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/General/Boot.md#fastboot)
-       - [Odin](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/General/Boot.md#odin)
+    - [Requirements](#recuirements)
+    - [Getting UEFI](#getting-uefi)
+    - [Method 1](#booting-uefi-method-1-recommended)
+    - [Method 2](#flashing-uefi-method-2)
+       - [Fastboot](#fastboot)
+       - [Odin](#odin)
 
 </td></tr> </table>
 

--- a/Mu-Qcom/OS/Linux.md
+++ b/Mu-Qcom/OS/Linux.md
@@ -124,10 +124,11 @@ Mount the usb according to the mount points above:
 
 Like this:
 ```
-~/uefi » mkdir tmp
-~/uefi » sudo mount /dev/sdx2 tmp/
-~/uefi » mkdir tmp/boot
-~/uefi » sudo mount /dev/sdx1 tmp/boot/
+~/uefi » su root
+[root@wisnia uefi]# mkdir tmp
+[root@wisnia uefi]# mount /dev/sdx2 tmp/
+[root@wisnia uefi]# mkdir tmp/boot
+[root@wisnia uefi]# mount /dev/sdx1 tmp/boot/
 ```
 
 ## Installing System (Step 3)

--- a/Mu-Qcom/OS/Linux.md
+++ b/Mu-Qcom/OS/Linux.md
@@ -172,6 +172,14 @@ You can get the UUID by using the blkid command:
 
 In this case UUID would be `cbcc0246-582a-4edf-933b-8a85011b7646`
 
+After that unmount device:
+
+```
+[root@wisnia tmp]# umount tmp/boot
+[root@wisnia tmp]# umount tmp/
+[root@wisnia tmp]# sync
+```
+
 ## Things to do post installation
 
 ### Connect to the internet

--- a/Mu-Qcom/OS/Linux.md
+++ b/Mu-Qcom/OS/Linux.md
@@ -185,8 +185,16 @@ After that unmount device:
 ### Connect to the internet
 
 1. Connect usb internet source (USB tethering or USB to ethernet card)
-2. Run `dhcpd &` after logging in to get ip address
+2. Run `dhcpcd &` after logging in to get ip address
 3. Check internet access by `ping 1.1.1.1`
+
+### Initialize the pacman keyring and populate the Arch Linux ARM package signing keys
+
+```
+pacman-key --init
+pacman-key --populate archlinuxarm
+```
+After doing this you can now use pacman to install packages
 
 ### Install Desktop Enviroment
 

--- a/Mu-Qcom/OS/Linux.md
+++ b/Mu-Qcom/OS/Linux.md
@@ -1,0 +1,184 @@
+# Arch Linux ARM
+
+Make sure to check the Status of your Device [here](https://github.com/Robotix22/Mu-Qcom/blob/main/Status.md).
+
+## Description
+
+This Guide will show you how to Arch Linux Arm on your Device.
+You can either use build-in UFS storage or external USB device.
+
+<table>
+<tr><th>Table of Contents</th></th>
+<tr><td>
+  
+- Installing Windows
+    - [What's needed](#needed-things)
+    - Partition Installation Device (Step 1)
+        - [Partition UFS](#partition-ufs)
+        - [Partition USB](#partition-usb)
+    - [Install](#installing-system-step-3)
+    - [Install Bootloader](#installing-and-configuring-refind-step-4)
+    - [Things to do post install](#things-to-do-post-installation)
+
+</td></tr> </table>
+
+## Needed Things:
+   - PC / Laptop with Linux (VM can be used / WSL to be tested)
+   - Unlocked Bootloader
+   - [UEFI Image](https://github.com/Robotix22/Mu-Qcom)
+   - [Generic Arch Linux Arm image](https://archlinuxarm.org/platforms/armv8/generic)
+   - [rEFInd](https://sourceforge.net/projects/refind/files/0.14.0.2/refind-bin-0.14.0.2.zip/download)
+
+   `If using UFS`
+   - Custom Recovery
+   - [ADB](https://developer.android.com/studio/releases/platform-tools#downloads)
+   - [Parted](https://renegade-project.tech/tools/parted.7z)
+   - [GDisk](https://renegade-project.tech/tools/gdisk.7z)
+
+## Partition UFS
+***⚠️ In this Section of the Guide you can easly brick your Device! ⚠️***
+
+***⚠️ NOTE: UNTESTED YOU DO IT AT YOUR OWN RISK (It should theoretically work) ⚠️***
+
+***⚠️ IF YOU DON'T KNOW WHAT ARE YOU DOING USE [USB METHOD](#partition-usb) INSTEAD ⚠️***
+
+
+Boot into your Custom Recovery and unmount `userdata`, then open Command Promt on your PC / Laptop and enter ADB Shell. <br />
+Once in ADB Shell create a directory called `worksapce` in `/`:
+```
+mkdir /workspace/
+```
+Then extract the .7z Files and push the content with `adb push` into the workspace folder:
+```
+adb push parted gdisk /workspace/
+```
+After you copied parted and gdisk to workspace make it executeable and run parted:
+```
+# NOTE: If your device has memory type eMMC, instead of sda use mmcblk0!
+chmod 744 parted gdisk
+./parted /dev/block/sda
+```
+Once you executed parted print the partition table:
+```
+(parted) print
+```
+Find userdata in output and note the Number, Start and End Address. <br />
+Example:
+```
+# NOTE: Don't use these Values it just an Example!
+Number  Start   End     Size    File system  Name             Flags
+38      141GB   241GB   100GB                userdata
+```
+Once you noted the Number, Start and End Address delete userdata and create is again but smaller: <br />
+```
+# NOTE: Some devices use f2fs filesystem for userdata, ext4 won't suit them!
+# If you have a problem with the number of partitions
+# (can’t create another partition), you can try:
+# NOTE: If your device has memory type eMMC, instead of sda use mmcblk0!
+sgdisk --resize-table 99 /dev/block/sda # 99 number of maximum allowed partitions
+# Deleting userdata will wipe all your data in Android!
+(parted) rm <Number>
+(parted) mkpart userdata ext4 <Start> <End / 2>
+```
+After shrinking userdata We can move on to creating the other Partitions:
+```
+(parted) mkpart esp fat32 <End / 2> <End / 2 + 512MB>
+(parted) mkpart arch ext4 <End / 2 + 512MB> <End>
+```
+Now we set esp to active by running: `set <Number> esp on`. <br />
+Once that is done we exit parted and reboot again to recovery:
+```
+(parted) quit
+reboot recovery
+```
+After that format the partitions:
+```
+mke2fs -t ext4 /dev/block/by-name/userdata        # Userdata
+mkfs.fat -F32 -s1 /dev/block/by-name/esp          # ESP
+mkfs.ext4 -f /dev/block/by-name/arch              # Arch root
+```
+If formating userdata gives a error reboot to recovery and format userdata in the Custom Recovery GUI. <br />
+
+***⚠️ End of the Dangerous Section! ⚠️***
+
+### Mounting UFS
+
+> TODO: How to mount UFS in linux
+
+## Partition USB
+
+Use your favorite way to partition the usb drive according to this sheme:
+
+| Mount point   | Partition     | Partition Type| Suggested size    |
+| ------------- | ------------- | ------------- | -------------     |
+| mnt/boot      | Esp Part      | fat32         | 1 GiB             |
+| mnt           | Arch Root     | ext4          | Rest of the device|
+
+### Mounting USB
+
+Create a temp folder somwhere on your pc and open a terminal.
+
+You can also copy the `ArchLinuxARM-aarch64-latest.tar.gz` you got ealier as you are gonna need it later
+
+Mount the usb according to the mount points above:
+
+Like this:
+```
+~/uefi » mkdir tmp
+~/uefi » sudo mount /dev/sdx2 tmp/
+~/uefi » mkdir tmp/boot
+~/uefi » sudo mount /dev/sdx1 tmp/boot/
+```
+
+## Installing System (Step 3)
+Unpack the rootfs onto the mounted device
+(NOTE: You **NEED** to be logged in as root, sudo won't work)
+
+```
+~/uefi » su root
+[root@wisnia uefi]# bsdtar -xpf ArchLinuxARM-aarch64-latest.tar.gz -C tmp/
+```
+
+## Installing and configuring Refind (Step 4)
+Okay so now you have a system, now you need a bootloader I'm gonna use refind but you could use something like GRUB2 if you wish.
+
+Unpack `refind-bin-x.xx.x.x.zip` into your temp directory.
+
+Copy over this files/folders from `/refind/` folder into the `tmp/boot/EFI/boot/` folder (if it dosen't exist create it)
+```
+drivers_aa64/
+icons/
+tools_aa64/
+refind_aa64.efi
+```
+
+rename `refind_aa64.efi` to `bootaa64.efi`
+
+Go back into the `tmp/` folder
+Rename theese `Image.gz` to `vmlinuz-linux.gz`
+
+Create `refind_linux.conf` file and add this line:
+
+```
+"Boot with UUID"   "rw root=UUID=<Arch Linux Root Part UUID>"
+```
+
+You can get the UUID by using the blkid command:
+```
+~/uefi » sudo blkid /dev/sdc2
+/dev/sdc2: UUID="cbcc0246-582a-4edf-933b-8a85011b7646" BLOCK_SIZE="4096" TYPE="ext4" PARTUUID="5f351c6d-8f34-4d6f-b958-f00646d5e640"
+```
+
+In this case UUID would be `cbcc0246-582a-4edf-933b-8a85011b7646`
+
+## Things to do post installation
+
+### Connect to the internet
+
+1. Connect usb internet source (USB tethering or USB to ethernet card)
+2. Run `dhcpd &` after logging in to get ip address
+3. Check internet access by `ping 1.1.1.1`
+
+### Install Desktop Enviroment
+
+> TODO: figure out how to force Xorg to use framebuffer provided by UEFI

--- a/Mu-Qcom/OS/Win.md
+++ b/Mu-Qcom/OS/Win.md
@@ -11,14 +11,14 @@ This Guide will show you how to install full Windows on your Device.
 <tr><td>
   
 - Installing Windows
-    - [What's needed](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md#needed-things)
-    - [Prepare](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md#preparing-step-1)
-        - [ISO](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md#windows-image-step-11)
-        - [Drivers](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md#windows-drivers-step-12)
-    - [Partition UFS](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md#partition-ufs-step-2)
-    - [Install](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md#installing-step-3)
-    - [Apply Drivers](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md#applying-drivers-step-4)
-- [Reinstall Windows](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md#reinstalling-windows)
+    - [What's needed](#needed-things)
+    - [Prepare](#preparing-step-1)
+        - [ISO](#windows-image-step-11)
+        - [Drivers](#windows-drivers-step-12)
+    - [Partition UFS](#partition-ufs-step-2)
+    - [Install](#installing-step-3)
+    - [Apply Drivers](#applying-drivers-step-4)
+- [Reinstall Windows](#reinstalling-windows)
 
 </td></tr> </table>
 
@@ -162,7 +162,7 @@ After that reboot to recovery and remove Mass Storage, then reboot into UEFI and
 
 After you boot into the system, you will be taken to OOBE or the desktop (depending on the image) and find that the USB does not work. In order to fix this you must:
 
-Boot into custom recovery and run them mass storage script according to the instructions that can be found for your device here [Mu-Qcom Guides](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/README.md)
+Boot into custom recovery and run them mass storage script according to the instructions that can be found for your device here [Mu-Qcom Guides](/Mu-Qcom/README.md)
 
 After that, in the command line of your PC, enter:
  ```

--- a/Mu-Qcom/OS/WinPE.md
+++ b/Mu-Qcom/OS/WinPE.md
@@ -11,16 +11,16 @@ This Guide will show you how to Install Windows PE on your Device.
 <tr><td>
   
 - Installing Windows PE
-    - [What's needed](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#things-you-need)
-    - [Installing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#installation)
-        - [Method 1](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#method-1-cust)
-            - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#preparing-step-1)
-            - [Formating](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#formating-cust-partition-step-2)
-            - [Copy Files](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#copying-windows-pe-files-step-3)
-        - [Method 2](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#method-2-partitions)
-            - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#preparing-step-1-1)
-            - [Partition](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#partitions-step-2)
-            - [Copy Files](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md#copying-winpe-files-step-3)
+    - [What's needed](#things-you-need)
+    - [Installing](#installation)
+        - [Method 1](#method-1-cust)
+            - [Preparing](#preparing-step-1)
+            - [Formating](#formating-cust-partition-step-2)
+            - [Copy Files](#copying-windows-pe-files-step-3)
+        - [Method 2](#method-2-partitions)
+            - [Preparing](#preparing-step-1-1)
+            - [Partition](#partitions-step-2)
+            - [Copy Files](#copying-winpe-files-step-3)
 
 </td></tr> </table>
 

--- a/Mu-Qcom/Porting/ACPI.md
+++ b/Mu-Qcom/Porting/ACPI.md
@@ -9,15 +9,15 @@ This Guide will show you how to create minimal ACPI Tables for a SoC that Device
 <tr><td>
   
 - Minimal ACPI Tables
-    - [Requirements](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#recuirements)
-    - [Explanation](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#explanation-for-acpi-tables)
-    - [Creating ACPI Tables](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#creating-acpi-tables-step-1)
-      - [Creating APIC](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#creating-apicdsl-step-11)
-      - [Creating APIC UniCore](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#creating-apicunicoredsl-step-12)
-      - [Creating DSDT](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#creating-dsdtminimaldsl-step-13)
-      - [Creating FACP](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#creating-facpdsl-step-14)
-      - [Creating GTDT](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#creating-gtdtdsl-step-15)
-    - [Compiling](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md#compiling-acpi-tables-step-2)
+    - [Requirements](#recuirements)
+    - [Explanation](#explanation-for-acpi-tables)
+    - [Creating ACPI Tables](#creating-acpi-tables-step-1)
+      - [Creating APIC](#creating-apicdsl-step-11)
+      - [Creating APIC UniCore](#creating-apicunicoredsl-step-12)
+      - [Creating DSDT](#creating-dsdtminimaldsl-step-13)
+      - [Creating FACP](#creating-facpdsl-step-14)
+      - [Creating GTDT](#creating-gtdtdsl-step-15)
+    - [Compiling](#compiling-acpi-tables-step-2)
 
 </td></tr> </table>
 

--- a/Mu-Qcom/Porting/Binaries.md
+++ b/Mu-Qcom/Porting/Binaries.md
@@ -9,12 +9,12 @@ This Guide will show you how to create a Patch for EFI Drivers from xbl
 <tr><td>
   
 - Patching Binaries
-    - [Requirements](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Binaries.md#requirements)
-    - [Method 1](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Binaries.md#requirements)
-       - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Binaries.md#preparing-step-1)
-       - [Analyze](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Binaries.md#analyzing-step-2)
-       - [Patch](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Binaries.md#patching-step-3)
-    - [Method 2](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Binaries.md#method-2-creating-a-patch)
+    - [Requirements](#requirements)
+    - [Method 1](#requirements)
+       - [Preparing](#preparing-step-1)
+       - [Analyze](#analyzing-step-2)
+       - [Patch](#patching-step-3)
+    - [Method 2](#method-2-creating-a-patch)
 
 </td></tr> </table>
 

--- a/Mu-Qcom/Porting/Device.md
+++ b/Mu-Qcom/Porting/Device.md
@@ -15,27 +15,27 @@ This Guide will show you how to create an minimal UEFI Port for your Device. <br
 <tr><td>
   
 - Adding Devices
-    - [Requirements](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#device-recuirements)
-    - [Copying Files](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#copying-files-step-1)
-    - [Creating Config](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-the-config-file-step-2)
-    - [Creating Files](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-files-step-3)
-         - [Creating .dsc & .dec & .fdf File](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-dsc--dec--fdf-file-step-31)
-              - [Creating .dsc](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-dsc-file-step-311)
-              - [Creating .dec](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-dec-file-step-312)
-              - [Creating .fdf](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-fdf-file-step-313)
-         - [Creating fdf.inc Files](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-fdfinc-files-step-32)
-              - [Creating ACPI.inc](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-acpiinc-step-321)
-              - [Creating APRIORI.inc](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-aprioriinc-step-322)
-              - [Creating DXE.inc](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-dxeinc-step-323)
-              - [Creating RAW.inc](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-rawinc-step-324)
-         - [Creating Config Map](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-configurationmap-library-step-33)
-         - [Creating MemoryMap](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-devicememorymap-library-step-34)
-         - [Creating Boot Script](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#creating-android-boot-image-script-step-35)
-    - [Building](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#building)
-    - [Troubleshooting](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#troubleshooting)
-         - [DxeCore](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#dxecore)
-         - [Crash](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#device-rebootsgets-stuck-on-something)
-         - [Synchronous Exception](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md#synchronous-exception)
+    - [Requirements](#device-requirements)
+    - [Copying Files](#copying-files-step-1)
+    - [Creating Config](#creating-the-config-file-step-2)
+    - [Creating Files](#creating-files-step-3)
+         - [Creating .dsc & .dec & .fdf File](#creating-dsc--dec--fdf-file-step-31)
+              - [Creating .dsc](#creating-dsc-file-step-311)
+              - [Creating .dec](#creating-dec-file-step-312)
+              - [Creating .fdf](#creating-fdf-file-step-313)
+         - [Creating fdf.inc Files](#creating-fdfinc-files-step-32)
+              - [Creating ACPI.inc](#creating-acpiinc-step-321)
+              - [Creating APRIORI.inc](#creating-aprioriinc-step-322)
+              - [Creating DXE.inc](#creating-dxeinc-step-323)
+              - [Creating RAW.inc](#creating-rawinc-step-324)
+         - [Creating Config Map](#creating-configurationmap-library-step-33)
+         - [Creating MemoryMap](#creating-devicememorymap-library-step-34)
+         - [Creating Boot Script](#creating-android-boot-image-script-step-35)
+    - [Building](#building)
+    - [Troubleshooting](#troubleshooting)
+         - [DxeCore](#dxecore)
+         - [Crash](#device-rebootsgets-stuck-on-something)
+         - [Synchronous Exception](#synchronous-exception)
 
 </td></tr> </table>
 
@@ -412,8 +412,8 @@ FILE FREEFORM = 7E374E25-8E01-4FEE-87F2-390C23C606CD {
 Now we continue with `APRIORI.inc`, Create `APRIORI.inc` in `./Platforms/<Device Vendor>/<Device Codename>Pkg/Include/`. <br />
 We need the order of the Binaries in `APRIORI.inc`, Use UEFITool to get the Order:
 
-![Preview](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/APRIORI1.png)
-![Preview](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/APRIORI2.png)
+![Preview](APRIORI1.png)
+![Preview](APRIORI2.png)
 
 Next we place all the Binaries in `APRIORI.inc` like this:
 ```
@@ -608,6 +608,6 @@ If The Phone reboots after booting UEFI the Issue is may an Driver again. <br />
 
 That also may happen if you Port UEFI. <br />
 
-![Preview](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Synchronous-Exception.jpg)
+![Preview](Synchronous-Exception.jpg)
 
 One of these Drivers causes the Issue, In that Example it it PILDxe, you can commend it for now.

--- a/Mu-Qcom/Porting/SoC.md
+++ b/Mu-Qcom/Porting/SoC.md
@@ -9,13 +9,13 @@ This Guide will show you how to make an UEFI Port for an Snapdragon SoC
 <tr><td>
   
 - Adding SoCs
-    - [Copying Files & Modify](https://github.com/Robotix22/UEFI-Guides/blob/main/MU-Qcom/Porting/SoC.md#copying-files--modify-them-step-1)
-        - [SoC Folder](https://github.com/Robotix22/UEFI-Guides/blob/main/MU-Qcom/Porting/SoC.md#creating-soc-folder-step-11)
-        - [Core Files](https://github.com/Robotix22/UEFI-Guides/blob/main/MU-Qcom/Porting/SoC.md#modify-dsc.inc--dec-file-step-12)
-            - [.dec File](https://github.com/Robotix22/UEFI-Guides/blob/main/MU-Qcom/Porting/SoC.md#modify-dec-file-step-121)
-            - [.dsc.inc File](https://github.com/Robotix22/UEFI-Guides/blob/main/MU-Qcom/Porting/SoC.md#modify-dsc.inc-file-step-122)
-        - [Modify SMBios](https://github.com/Robotix22/UEFI-Guides/blob/main/MU-Qcom/Porting/SoC.md#modify-smbios-step-13)
-        - [Modify Librarys](https://github.com/Robotix22/UEFI-Guides/blob/main/MU-Qcom/Porting/SoC.md#modify-librarys-step-14)
+    - [Copying Files & Modify](#copying-files--modify-them-step-1)
+        - [SoC Folder](#creating-soc-folder-step-11)
+        - [Core Files](#modify-dsc.inc--dec-file-step-12)
+            - [.dec File](#modify-dec-file-step-121)
+            - [.dsc.inc File](#modify-dsc.inc-file-step-122)
+        - [Modify SMBios](#modify-smbios-step-13)
+        - [Modify Librarys](#modify-librarys-step-14)
 
 </td></tr> </table>
 

--- a/Mu-Qcom/README.md
+++ b/Mu-Qcom/README.md
@@ -7,20 +7,20 @@ If you are uncomfortable modding your device, please don't follow any of the gui
 
 ## General guides:
 
-   - [Booting](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/General/Boot.md)
+   - [Booting](General/Boot.md)
 
 ## Porting guides:
 
-   - [Adding SoCs](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/SoC.md)
-       - [Creating minimal ACPI tables](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/ACPI.md) **NOTE: Not finished!**
-   - [Adding devices](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Device.md) **Outdated!**
-       - [Patching binaries](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Porting/Binaries.md) **NOTE: Not finished!**
+   - [Adding SoCs](Porting/SoC.md)
+       - [Creating minimal ACPI tables](Porting/ACPI.md) **NOTE: Not finished!**
+   - [Adding devices](Porting/Device.md) **Outdated!**
+       - [Patching binaries](Porting/Binaries.md) **NOTE: Not finished!**
 
 ## Device guides:
 
 ### Samsung Galaxy Tab S8 5G
 
-   - [Enabling mass storage](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Galaxy-Tab-S8-5G/Mass-Storage.md)
+   - [Enabling mass storage](Devices/Galaxy-Tab-S8-5G/Mass-Storage.md)
 
 ### Samsung Galaxy Z Fold 3 5G
 
@@ -48,7 +48,7 @@ If you are uncomfortable modding your device, please don't follow any of the gui
 
 ### OnePlus 8T
 
-   - [Enabling mass storage](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/OnePlus-8T/Mass-Storage.md)
+   - [Enabling mass storage](Devices/OnePlus-8T/Mass-Storage.md)
 
 ### Xiaomi Redmi Note 12 Pro
 
@@ -56,7 +56,7 @@ If you are uncomfortable modding your device, please don't follow any of the gui
 
 ### Xiaomi Redmi 10C
 
-   - [Enabling mass storage](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-10C/Mass-Storage.md)
+   - [Enabling mass storage](Devices/Xiaomi-Redmi-10C/Mass-Storage.md)
 
 ### Xiaomi Mi A3
 
@@ -64,7 +64,7 @@ If you are uncomfortable modding your device, please don't follow any of the gui
 
 ### Xiaomi Redmi Note 8/8T
 
-   - [Enabling mass storage](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Redmi-Note-8/Mass-Storage.md)
+   - [Enabling mass storage](Devices/Xiaomi-Redmi-Note-8/Mass-Storage.md)
 
 ### Xiaomi Redmi 9T
 
@@ -72,7 +72,7 @@ If you are uncomfortable modding your device, please don't follow any of the gui
 
 ### Xiaomi Mi Max 3
 
-   - [Enabling mass storage](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Xiaomi-Mi-Max-3/Mass-Storage.md)
+   - [Enabling mass storage](Devices/Xiaomi-Mi-Max-3/Mass-Storage.md)
 
 ### Huawei Y6 2018
 
@@ -94,7 +94,7 @@ If you are uncomfortable modding your device, please don't follow any of the gui
 
 ### Samsung
 
-   - [Fixing UFS](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Vendors/Samsung/Fix-UFS.md)
+   - [Fixing UFS](Vendors/Samsung/Fix-UFS.md)
 
 ### Xiaomi
 
@@ -104,9 +104,9 @@ If you are uncomfortable modding your device, please don't follow any of the gui
 
 ### Windows
 
-   - [Installing Windows PE](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/WinPE.md)
-   - [Installing Windows](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Win.md)
+   - [Installing Windows PE](OS/WinPE.md)
+   - [Installing Windows](OS/Win.md)
 
 ### Linux
 
-   - ~~[Installing Linux](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/OS/Linux.md)~~ Coming soon
+   - [Installing Linux](OS/Linux.md)

--- a/Mu-Qcom/Vendors/Samsung/Fix-UFS.md
+++ b/Mu-Qcom/Vendors/Samsung/Fix-UFS.md
@@ -11,11 +11,11 @@ This Guide will show you how to make UFS usable under Windows and Linux.
 <tr><td>
   
 - Enabling Mass Storage
-   - [What's needed](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Vendors/Samsung/Fix-UFS.md#things-you-need)
-   - [Preparing](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Vendors/Samsung/Fix-UFS.md#preparing-step-1)
-   - [Fix](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Vendors/Samsung/Fix-UFS.md#fix-ufs-step-2)
-     - [Set Online](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Vendors/Samsung/Fix-UFS.md#setting-ufs-online-step-21)
-     - [Restore GPT](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Vendors/Samsung/Fix-UFS.md#restoring-ufs-step-22)
+   - [What's needed](#things-you-need)
+   - [Preparing](#preparing-step-1)
+   - [Fix](#fix-ufs-step-2)
+     - [Set Online](#setting-ufs-online-step-21)
+     - [Restore GPT](#restoring-ufs-step-22)
 
 </td></tr> </table>
 

--- a/Mu-Tegra/General/Boot.md
+++ b/Mu-Tegra/General/Boot.md
@@ -9,9 +9,9 @@ This Guide will show your how to boot UEFI on your Device.
 <tr><td>
 
 - Booting UEFI
-    - [Requirements](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Tegra/General/Boot.md#recuirements)
-    - [Getting UEFI](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Tegra/General/Boot.md#getting-uefi)
-    - [UEFI Chainload](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Tegra/General/Boot.md#uefi-chainload)
+    - [Requirements](#recuirements)
+    - [Getting UEFI](#getting-uefi)
+    - [UEFI Chainload](#uefi-chainload)
 
 </td></tr> </table>
 

--- a/Mu-Tegra/README.md
+++ b/Mu-Tegra/README.md
@@ -2,7 +2,7 @@
 
 ## General Guides:
 
-   - [Booting](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Tegra/General/Boot.md) **Outdated!**
+   - [Booting](General/Boot.md) **Outdated!**
 
 ## Porting Guides:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # UEFI Guides
 
-## [Mu-Qcom](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/README.md)
-## [Mu-Tegra](https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Tegra/README.md)
+## [Mu-Qcom](Mu-Qcom/README.md)
+## [Mu-Tegra](Mu-Tegra/README.md)


### PR DESCRIPTION
I have added an arch linux arm guide (the instalation using UFS is untested, I will test it once I get UFS working on my device)

I have changed absolute paths to relative ones (Now the links work in forks and offline)
Also where there was an absolute path referencing the same file it was replaced like this:
`https://github.com/Robotix22/UEFI-Guides/blob/main/Mu-Qcom/Devices/Galaxy-Tab-S8-5G/Mass-Storage.md#things-you-need` -> `#things-you-need`
I think it is better to have it that way.