### PR TITLE
Add a52sxq mass storage guide

### DIFF
--- a/Mu-Qcom/Devices/Galaxy-A52s-5G/Mass-Storage.md
+++ b/Mu-Qcom/Devices/Galaxy-A52s-5G/Mass-Storage.md
@@ -1,0 +1,41 @@
+# Enabling Mass Storage
+
+## Description
+
+This Guide will show you how to enable Mass Storage in TWRP for the Galaxy A52s 5G.
+
+<table>
+<tr><th>Table of Contents</th></th>
+<tr><td>
+  
+- Enabling Mass Storage
+   - [What's needed](#things-you-need)
+   - [Preparing](#preparing-step-1)
+   - [Enable](#enable-mass-storage-step-2)
+
+</td></tr> </table>
+
+## Things you need:
+   - PC / Laptop
+   - [TWRP](https://twrp.me/samsung/samsunggalaxya52s5G.html)
+   - Unlocked Bootloader
+   - Modded [msc.sh](Resources/msc.sh) script
+
+## Preparing (Step 1)
+
+Okay, First you need to boot into the Custom Recovery (TWRP) and then enable MTP if disabled (Mount -> Enable MTP). <br />
+Then download the msc.sh script and push it to your Device, For Example to `/sdcard/`: <br />
+```
+adb push <Path to msc.sh> /sdcard/
+```
+
+## Enable (Step 2)
+
+After you pushed msc.sh to `/sdcard/` make it executeable and run it **only once**:
+```
+adb shell
+chmod 744 /sdcard/msc.sh
+./sdcard/msc.sh
+```
+There will be some errors in output but that dosen't break anything. <br />
+On your PC or Laptop should now show up all the partitions of your Tab from LUN 0.

--- a/Mu-Qcom/Devices/Galaxy-A52s-5G/Resources/msc.sh
+++ b/Mu-Qcom/Devices/Galaxy-A52s-5G/Resources/msc.sh
@@ -1,0 +1,6 @@
+#!/sbin/sh
+echo 0xEF > /config/usb_gadget/g1/bDeviceClass; echo 0x02 > /config/usb_gadget/g1/bDeviceSubClass; echo 0x01 > /config/usb_gadget/g1/bDeviceProtocol; echo 0x00 > /config/usb_gadget/g1/functions/mass_storage.0/lun.0/cdrom; echo 0x00 > /config/usb_gadget/g1/functions/mass_storage.0/lun.0/ro
+ln -s /config/usb_gadget/g1/functions/mass_storage.0/ /config/usb_gadget/g1/configs/b.1/
+echo /dev/block/sda > /config/usb_gadget/g1/configs/b.1/mass_storage.0/lun.0/file
+echo 0 > /config/usb_gadget/g1/configs/b.1/mass_storage.0/lun.0/removable
+sh -c 'echo > /config/usb_gadget/g1/UDC; echo a800000.dwc3 > /config/usb_gadget/g1/UDC' &

--- a/Mu-Qcom/README.md
+++ b/Mu-Qcom/README.md
@@ -29,6 +29,10 @@ If you are uncomfortable modding your device, please don't follow any of the gui
 
    - [Enabling mass storage](Devices/Galaxy-Tab-S8-5G/Mass-Storage.md)
 
+### Samsung Galaxy A52s 5G
+
+   - [Enabling mass storage](Devices/Galaxy-A52s-5G/Mass-Storage.md)
+
 ### OnePlus 8T
 
    - [Enabling mass storage](Devices/OnePlus-8T/Mass-Storage.md)


### PR DESCRIPTION
Since Galaxy Tab S8 5G msc.sh doesn't work on a52sxq, dedicated mass storage guide for Galaxy A52s 5G